### PR TITLE
added condition to reveal tab contact

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,6 +1,6 @@
 class Offer < ApplicationRecord
   belongs_to :request
-  STATUS = ["Pending", "Declined", "Accepted"]
+  STATUS = ["Offer made", "Offer declined", "Offer accepted"]
   validates :content, presence: true, length: { minimum: 25 }
   validates :occurs_on, presence: true
   validates :time, presence: true, numericality: { only_integer: true }

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,10 +1,10 @@
 class Request < ApplicationRecord
   belongs_to :user
   belongs_to :expert
-  has_many :offers
+  has_one :offer
   has_many_attached :pictures
 
-  STATUS = ["Pending", "Awaiting", "Accepted"]
+  STATUS = ["Pending", "Offer made", "Offer declined", "Offer accepted", "Canceled", "Rejected"]
   validates :title, presence: true, length: { maximum: 30 }
   validates :description, presence: true, length: { minimum: 25 }
   validates :status, inclusion: { in: STATUS }

--- a/app/views/requests/_4contact.html.erb
+++ b/app/views/requests/_4contact.html.erb
@@ -1,22 +1,26 @@
-<p>
-  Now that you accepted the offer 🎉, we share <%= @request.expert.user.first_name %> contact details. Please keep them confidential!
-</p>
-<%= cl_image_tag @request.expert.user.photo.key, height: 300, width: 400, crop: :fill %>
+<% if @request.status == "Offer accepted" %>
+      <p>
+        Now that you accepted the offer 🎉, we share <%= @request.expert.user.first_name %> contact details. Please keep them confidential!
+      </p>
+      <%= cl_image_tag @request.expert.user.photo.key, height: 300, width: 400, crop: :fill %>
 
-<div class="title-subsection">Expert full name</div>
-  <%= @request.expert.user.first_name %>
-  <%= @request.expert.user.last_name %>
+      <div class="title-subsection">Expert full name</div>
+        <%= @request.expert.user.first_name %>
+        <%= @request.expert.user.last_name %>
 
-<div class="title-subsection">Phone</div>
-  <%= @request.expert.user.phone_number %>
+      <div class="title-subsection">Phone</div>
+        <%= @request.expert.user.phone_number %>
 
-<div class="title-subsection">Address</div>
-  <%= @request.expert.user.address %>
+      <div class="title-subsection">Address</div>
+        <%= @request.expert.user.address %>
 
-<div class="title-subsection">Description</div>
-  <%= @request.expert.description %>
+      <div class="title-subsection">Description</div>
+        <%= @request.expert.description %>
 
-<div class="title-subsection">Expertise</div>
-    <% @request.expert.fields.each do |field| %>
-      <div><p class="card-tag"><%= field.expertise %></p></div>
-      <% end %>
+      <div class="title-subsection">Expertise</div>
+          <% @request.expert.fields.each do |field| %>
+            <div><p class="card-tag"><%= field.expertise %></p></div>
+            <% end %>
+    <% else %>
+        <p>Sorry, you'll only have access to the expert contact details once you accept their offer 😊.</p>
+    <% end %>


### PR DESCRIPTION
A request has one offer

Reviewed statuses request. These labels need to be understandable by both personas 
- **Pending**: request made, no offer yet
- **Canceled**: request pending canceled by the requester (P2)
- **Offer made**
- **Offer declined**
- **Offer accepted**
- **Rejected**: request rejected by expert (P2)

Implemented a condition "request.status = "Offer accepted" to reveal the content the tab "confirmation"
