### PR TITLE
Caro/reject and decline

### DIFF
--- a/app/assets/stylesheets/pages/_my_requests_index.scss
+++ b/app/assets/stylesheets/pages/_my_requests_index.scss
@@ -56,6 +56,13 @@
   background-color: $translucide;
 }
 
+.line-no-hover {
+  padding: 0px 20px;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
 .line {
   padding: 0px 20px;
   position: relative;
@@ -84,7 +91,7 @@
   background-color: $mmviolet;
   height: 70px;
 
-  p, a {
+  p, a, i {
     color: white;
   }
 
@@ -98,7 +105,7 @@
   background-color: $mmviolet;
   height: 70px;
 
-  p, a {
+  p, a, i {
     color: white;
     font-weight: 700;
   }

--- a/app/assets/stylesheets/pages/_my_requests_show.scss
+++ b/app/assets/stylesheets/pages/_my_requests_show.scss
@@ -4,6 +4,8 @@
   margin: 20px;
   background-color: rgba(0, 0, 0, 0.04);
   border-radius: 20px;
+  position: fixed;
+  width: 46%;
 }
 
 .steps-buttons {

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -45,8 +45,7 @@ class RequestsController < ApplicationController
     @request.user = current_user
     @request.address = current_user.address
     if @request.save
-      redirect_to my_requests_path, notice: "The expert has been notified."
-      # change redirect to the request id
+      redirect_to request_path(@request), notice: "The expert has been notified."
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,39 +1,27 @@
 class RequestsController < ApplicationController
-  # this is for "my requests", the index of user's request
+  before_action :set_user_request, only: %i[index show]
+  before_action :set_expert_request, only: %i[requests_received requests_received_show]
+
+  # my resquests > index, for USER
   def index
-    @all_requests = Request.where(user: current_user).order(updated_at: :desc)
-    @past_requests = @all_requests.select { |request| request.offer.occurs_on < Time.now if request.offer.present? }
-    @cancelled_requests = @all_requests.where(status: "Cancelled")
-    @pending_requests = @all_requests - @past_requests - @cancelled_requests
+    # before action
   end
 
-  # this is for "my requests", the show page of user's request
+  # my resquests > show, for USER
   def show
+    # before action
     @request = Request.find(params[:id])
-    @all_requests = Request.where(user: current_user).order(updated_at: :desc)
-    @past_requests = @all_requests.select { |request| request.offer.occurs_on < Time.now if request.offer.present? }
-    @cancelled_requests = @all_requests.where(status: "Cancelled")
-    @pending_requests = @all_requests - @past_requests - @cancelled_requests
     @message = Message.new
   end
 
-  # this is for "requests received", the index of all requests an expert received
+  # requests received" > index, for EXPERT
   def requests_received
-    @all_requests = Request.where(expert: current_user.expert).order(updated_at: :desc)
-    rejected_requests = @all_requests.where(status: "Rejected")
-    @cancelled_requests = @all_requests.where(status: "Cancelled")
-    @past_requests = @all_requests.select { |request| request.offer.occurs_on < Time.now if request.offer.present? }
-    @pending_requests = @all_requests - rejected_requests - @past_requests - @cancelled_requests
+    # before action
   end
 
-  # this is for "requests received", the show of each request an expert received
+  # requests received" > show, for EXPERT
   def requests_received_show
-    @all_requests = Request.where(expert: current_user.expert).order(updated_at: :desc)
-    rejected_requests = @all_requests.where(status: "Rejected")
-    @cancelled_requests = @all_requests.where(status: "Cancelled")
-    @past_requests = @all_requests.select { |request| request.offer.occurs_on < Time.now if request.offer.present? }
-    @pending_requests = @all_requests - rejected_requests - @past_requests - @cancelled_requests
-
+    # before action
     @request = Request.find(params[:id])
     @message = Message.new
     @expert = @request.expert
@@ -55,10 +43,10 @@ class RequestsController < ApplicationController
     @expert = Expert.find(params[:expert_id])
     @request.expert = @expert
     @request.user = current_user
-    @request.address = current_user.address # this will need to be adapted when the address can be different
+    @request.address = current_user.address
     if @request.save
       redirect_to my_requests_path, notice: "The expert has been notified."
-      # the redirect will change to the requests index
+      # change redirect to the request id
     else
       render :new, status: :unprocessable_entity
     end
@@ -68,7 +56,13 @@ class RequestsController < ApplicationController
     @request = Request.find(params[:id])
     @request.update(status: "Rejected")
     @request.save
-    redirect_to requests_received_path, notice: "The request was rejected."
+    redirect_to requests_received_path, notice: "The request has been rejected."
+  end
+
+  def destroy_rejected_request
+    @request = Request.find(params[:id])
+    @request.destroy
+    redirect_to my_requests_path, status: :see_other, notice: "The request has been deleted."
   end
 
   def cancel
@@ -78,7 +72,7 @@ class RequestsController < ApplicationController
     redirect_to my_requests_path, notice: "The request has been cancelled."
   end
 
-  def destroy_client_request
+  def destroy_cancelled_request
     @request = Request.find(params[:id])
     @request.destroy
     redirect_to requests_received_path, status: :see_other, notice: "The request has been deleted."
@@ -88,5 +82,22 @@ class RequestsController < ApplicationController
 
   def request_params
     params.require(:request).permit(:title, :description, :estimated_time, :address, pictures: [])
+  end
+
+  # question for Pedro, lots of the code is the same, can we further refactor?
+  def set_user_request
+    all_requests = Request.where(user: current_user).order(updated_at: :desc)
+    @rejected_requests = all_requests.where(status: "Rejected")
+    @cancelled_requests = all_requests.where(status: "Cancelled")
+    @past_requests = all_requests.select { |request| request.offer.occurs_on.to_date < Date.today if request.status == "Offer accepted" }
+    @pending_requests = all_requests - @rejected_requests - @cancelled_requests - @past_requests
+  end
+
+  def set_expert_request
+    all_requests = Request.where(expert: current_user.expert).order(updated_at: :desc)
+    @rejected_requests = all_requests.where(status: "Rejected")
+    @cancelled_requests = all_requests.where(status: "Cancelled")
+    @past_requests = all_requests.select { |request| request.offer.occurs_on.to_date < Date.today if request.status == "Offer accepted" }
+    @pending_requests = all_requests - @rejected_requests - @cancelled_requests - @past_requests
   end
 end

--- a/app/views/experts/index.html.erb
+++ b/app/views/experts/index.html.erb
@@ -71,7 +71,8 @@
             <h4><%= expert.user.first_name %></h4>
             <p><%= expert.price_per_hour %>€/h</p>
             <% if user_signed_in? %>
-              <p><%= expert.user.distance_to(current_user.address).to_i %>km from you</p>
+              <p><%=  %>km from you (uncomment)</p>
+              <%# ADD THIS ABOVE expert.user.distance_to(current_user.address).to_i %>
             <% end %>
 
             <%# rating will need to be added here %>
@@ -109,7 +110,8 @@
                         </div>
 
                         <% if user_signed_in? %>
-                          <p><%= expert.user.distance_to(current_user.address).to_i %>km from you</p>
+                          <p><%=  %>km from you (uncomment)</p>
+                          ADD THIS ABOVE expert.user.distance_to(current_user.address).to_i
                         <% end %>
 
                         <p class="grow"><%= expert.description %></p>

--- a/app/views/experts/index.html.erb
+++ b/app/views/experts/index.html.erb
@@ -111,7 +111,7 @@
 
                         <% if user_signed_in? %>
                           <p><%=  %>km from you (uncomment)</p>
-                          ADD THIS ABOVE expert.user.distance_to(current_user.address).to_i
+                          <%# ADD THIS ABOVE expert.user.distance_to(current_user.address).to_i %>
                         <% end %>
 
                         <p class="grow"><%= expert.description %></p>

--- a/app/views/requests/_1request.html.erb
+++ b/app/views/requests/_1request.html.erb
@@ -11,7 +11,9 @@
   <%= cl_image_tag picture.key, height: 250 %>
 <% end %>
 
-<p class="mb-1 mt-4"><em>Did you find an other expert ?</em></p>
-<div class="steps-buttons">
-  <%= link_to "Cancel request", request_cancelled_path(@request), data: {turbo_method: "patch", turbo_confirm: "Are you sure you want to cancel this request? It will no longer appear on the list."}, class: "step-button decline-button" %>
-</div>
+<% if @request.status != "Offer accepted" %>
+  <p class="mb-1 mt-4"><em>Did you find an other expert or do you no longer need this?</em></p>
+  <div class="steps-buttons">
+    <%= link_to "Cancel request", request_cancelled_path(@request), data: {turbo_method: "patch", turbo_confirm: "Are you sure you want to cancel this request? It will no longer appear on the list."}, class: "step-button decline-button" %>
+  </div>
+<% end %>

--- a/app/views/requests/_91request.html.erb
+++ b/app/views/requests/_91request.html.erb
@@ -5,7 +5,8 @@
 <p><%= @request.create_date %></p>
 
 <p class="title-subsection">Client</p>
-<p class="mb-0"><%= @request.user.first_name %>, <%= @request.user.distance_to(current_user.address).to_i %>km from you</p>
+<p class="mb-0"><%= @request.user.first_name %>, <%=  %>km from you (to be uncommented)</p>
+<%# ADD THIS ABOVE: @request.user.distance_to(current_user.address).to_i %>
 <p>(You will get <%= @request.user.first_name %>'s address and contact details once the offer is confirmed.)</p>
 
 <p class="title-subsection">Description</p>

--- a/app/views/requests/_91request.html.erb
+++ b/app/views/requests/_91request.html.erb
@@ -16,7 +16,9 @@
   <%= cl_image_tag picture.key, height: 250 %>
 <% end %>
 
-<p class="mb-1 mt-4"><em>This request doesn't match your competecences field, is located too far or you don't have the time?</em></p>
-<div class="steps-buttons">
-  <%= link_to "Reject request", request_rejected_path(@request), data: {turbo_method: "patch", turbo_confirm: "Are you sure you want to reject this request? It will no longer appear on the list."}, class: "step-button decline-button" %>
-</div>
+<% if @request.status != "Offer accepted" %>
+  <p class="mb-1 mt-4"><em>This request doesn't match your competecences field, is located too far or you don't have the time?</em></p>
+  <div class="steps-buttons">
+    <%= link_to "Reject request", request_rejected_path(@request), data: {turbo_method: "patch", turbo_confirm: "Are you sure you want to reject this request? It will no longer appear on the list."}, class: "step-button decline-button" %>
+  </div>
+<% end %>

--- a/app/views/requests/_my_requests.html.erb
+++ b/app/views/requests/_my_requests.html.erb
@@ -40,8 +40,6 @@
     </div>
 
     <%# REJECTED REQUESTS TABLE %>
-    <%# here comes the requests that experts rejected %>
-    <%# the client should be able to delete those %>
     <br><br>
     <h3>Rejected requests</h3>
 
@@ -68,19 +66,18 @@
             pair_or_impair = "pair"
           end %>
 
-          <div class="line <%= pair_or_impair %> <%= params[:id].to_i == request.id ? "line-active" : "" %>">
+          <div class="line-no-hover <%= pair_or_impair %> <%= params[:id].to_i == request.id ? "line-active" : "" %>">
             <p class="col1-size"><%= request.title %></p>
             <p class="col2-size"><%= request.user.first_name %></p>
             <p class="col3-size"><%= request.update_date %></p>
 
-            <%# we should remove the - I'm leaving it to check we only get cancellde stuff %>
             <div class="col4-size d-flex justify-content-end">
-              <p class="status-tag <%= request.tag_color %>"><%= request.status %></p>
+              <%= link_to "Find new expert", experts_path, class:"me-2 text-decoration-underline" %>
+              <%= link_to destroy_rejected_request_path(request), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
+                <i class="fa-regular fa-trash-can"></i>
+              <% end %>
             </div>
 
-            <%= link_to destroy_rejected_request_path(request), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
-              <i class="fa-regular fa-trash-can"></i>
-            <% end %>
           </div>
         <% end %>
       <% end %>
@@ -118,11 +115,6 @@
                 <p class="col2-size"><%= request.expert.user.first_name%></p>
                 <p class="col3-size"><%= request.offer.occurs_on.strftime("%B %d, %Y") %></p>
                 <%# need to add a method for X days ago - or since it is in the past it is not worth it? %>
-
-                <%# to be deleted %>
-                <div class="col4-size d-flex justify-content-end">
-                  <p class="status-tag <%= request.tag_color %>"><%= request.status %></p>
-                </div>
             <% end %>
 
             <% users = [] %>

--- a/app/views/requests/_my_requests.html.erb
+++ b/app/views/requests/_my_requests.html.erb
@@ -1,5 +1,6 @@
+<%# adapt indentation %>
+
 <div class="my-requests-box">
-  <div class="pending-requests">
 
     <%# PENDING REQUESTS TABLE %>
     <h3>Pending requests</h3>
@@ -41,10 +42,54 @@
     <%# REJECTED REQUESTS TABLE %>
     <%# here comes the requests that experts rejected %>
     <%# the client should be able to delete those %>
+    <br><br>
+    <h3>Rejected requests</h3>
+
+  <div class="requests-table">
+    <div class="titles">
+      <p class="col1-size">Request</p>
+      <p class="col2-size">Client</p>
+      <p class="col3-size">Last update</p>
+    </div>
+
+    <div class="lines">
+
+      <% if @rejected_requests.nil? %>
+        <p>No rejected requests 😊</p>
+
+      <% else %>
+        <% counter = 0 %>
+
+        <% @rejected_requests.each do |request| %>
+          <% counter += 1 %>
+          <% if counter % 2 == 1
+            pair_or_impair = "impair"
+          else
+            pair_or_impair = "pair"
+          end %>
+
+          <div class="line <%= pair_or_impair %> <%= params[:id].to_i == request.id ? "line-active" : "" %>">
+            <p class="col1-size"><%= request.title %></p>
+            <p class="col2-size"><%= request.user.first_name %></p>
+            <p class="col3-size"><%= request.update_date %></p>
+
+            <%# we should remove the - I'm leaving it to check we only get cancellde stuff %>
+            <div class="col4-size d-flex justify-content-end">
+              <p class="status-tag <%= request.tag_color %>"><%= request.status %></p>
+            </div>
+
+            <%= link_to destroy_rejected_request_path(request), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
+              <i class="fa-regular fa-trash-can"></i>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 
 
     <%# PAST OFFERS TABLE %>
-    <br>
+    <br><br>
     <h3>Past offers</h3>
 
     <div class="requests-table">
@@ -73,6 +118,11 @@
                 <p class="col2-size"><%= request.expert.user.first_name%></p>
                 <p class="col3-size"><%= request.offer.occurs_on.strftime("%B %d, %Y") %></p>
                 <%# need to add a method for X days ago - or since it is in the past it is not worth it? %>
+
+                <%# to be deleted %>
+                <div class="col4-size d-flex justify-content-end">
+                  <p class="status-tag <%= request.tag_color %>"><%= request.status %></p>
+                </div>
             <% end %>
 
             <% users = [] %>
@@ -92,5 +142,4 @@
       </div>
     </div>
 
-  </div>
 </div>

--- a/app/views/requests/_requests_received.html.erb
+++ b/app/views/requests/_requests_received.html.erb
@@ -63,19 +63,17 @@
             pair_or_impair = "pair"
           end %>
 
-          <div class="line <%= pair_or_impair %> <%= params[:id].to_i == request.id ? "line-active" : "" %>">
+          <div class="line-no-hover <%= pair_or_impair %> <%= params[:id].to_i == request.id ? "line-active" : "" %>">
             <p class="col1-size"><%= request.title %></p>
             <p class="col2-size"><%= request.user.first_name %></p>
             <p class="col3-size"><%= request.update_date %></p>
 
-            <%# we should remove the - I'm leaving it to check we only get cancellde stuff %>
             <div class="col4-size d-flex justify-content-end">
-              <p class="status-tag <%= request.tag_color %>"><%= request.status %></p>
+              <%= link_to destroy_cancelled_request_path(request), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
+                <i class="fa-regular fa-trash-can"></i>
+              <% end %>
             </div>
 
-            <%= link_to destroy_cancelled_request_path(request), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
-              <i class="fa-regular fa-trash-can"></i>
-            <% end %>
           </div>
         <% end %>
       <% end %>
@@ -111,11 +109,6 @@
             <p class="col1-size"><%= request.title %></p>
             <p class="col2-size"><%= request.user.first_name %></p>
             <p class="col3-size"><%= request.offer.occurs_on.strftime("%B %d, %Y") %></p>
-
-            <%# we should remove the - I'm leaving it to check we only get accepted stuff %>
-            <div class="col4-size d-flex justify-content-end">
-              <p class="status-tag <%= request.tag_color %>"><%= request.status %></p>
-            </div>
           </div>
         <% end %>
       <% end %>

--- a/app/views/requests/_requests_received.html.erb
+++ b/app/views/requests/_requests_received.html.erb
@@ -38,52 +38,88 @@
   </div>
 
   <%# CANCELLED REQUESTS TABLE %>
-  <%# here comes the requests that clients cancelled %>
-  <%# the expert should be able to delete those %>
-  <h3>Cancelled Requests</h3>
+  <br><br>
+  <h3>Cancelled requests</h3>
 
   <div class="requests-table">
     <div class="titles">
       <p class="col1-size">Request</p>
       <p class="col2-size">Client</p>
       <p class="col3-size">Last update</p>
-      <p class="col4-size">Status</p>
     </div>
+
+    <div class="lines">
+      <% if @cancelled_requests.nil? %>
+        <p>No cancelled requests 😊</p>
+
+      <% else %>
+        <% counter = 0 %>
+
+        <% @cancelled_requests.each do |request| %>
+          <% counter += 1 %>
+          <% if counter % 2 == 1
+            pair_or_impair = "impair"
+          else
+            pair_or_impair = "pair"
+          end %>
+
+          <div class="line <%= pair_or_impair %> <%= params[:id].to_i == request.id ? "line-active" : "" %>">
+            <p class="col1-size"><%= request.title %></p>
+            <p class="col2-size"><%= request.user.first_name %></p>
+            <p class="col3-size"><%= request.update_date %></p>
+
+            <%# we should remove the - I'm leaving it to check we only get cancellde stuff %>
+            <div class="col4-size d-flex justify-content-end">
+              <p class="status-tag <%= request.tag_color %>"><%= request.status %></p>
+            </div>
+
+            <%= link_to destroy_cancelled_request_path(request), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
+              <i class="fa-regular fa-trash-can"></i>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
   </div>
 
-  <div class="lines">
-    <% counter = 0 %>
-    <% if @cancelled_requests.nil? %>
-    <p>No cancelled requests yet...</p>
-    <% else %>
-      <% @cancelled_requests.each do |request| %>
+  <%# PAST OFFERS TABLE %>
+  <br><br>
+  <h3>Past offers</h3>
+
+  <div class="requests-table">
+
+    <div class="titles">
+      <p class="col1-size">Request request</p>
+      <p class="col2-size">Client</p>
+      <p class="col3-size">Delivery date</p>
+    </div>
+
+    <div class="lines">
+      <% counter = 0 %>
+
+      <% @past_requests.each do |request| %>
         <% counter += 1 %>
         <% if counter % 2 == 1
           pair_or_impair = "impair"
         else
           pair_or_impair = "pair"
         end %>
-        <div class="line <%= pair_or_impair %> <%= params[:id].to_i == request.id ? "line-active" : "" %>">
-          <p class="col1-size"><%= request.title %></p>
-          <p class="col2-size"><%= request.user.first_name %></p>
-          <p class="col3-size"><%= request.update_date %></p>
-          <div class="col4-size d-flex justify-content-end">
-            <p class="status-tag <%= request.tag_color %>"><%= request.status %></p>
+
+        <%= link_to request_received_path(request) do %>
+          <div class="line <%= pair_or_impair %> <%= params[:id].to_i == request.id ? "line-active" : "" %>">
+            <p class="col1-size"><%= request.title %></p>
+            <p class="col2-size"><%= request.user.first_name %></p>
+            <p class="col3-size"><%= request.offer.occurs_on.strftime("%B %d, %Y") %></p>
+
+            <%# we should remove the - I'm leaving it to check we only get accepted stuff %>
+            <div class="col4-size d-flex justify-content-end">
+              <p class="status-tag <%= request.tag_color %>"><%= request.status %></p>
+            </div>
           </div>
-          <%= link_to request_deleted_path(request), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
-            <i class="fa-regular fa-trash-can"></i>
-          <% end %>
-        </div>
+        <% end %>
       <% end %>
-    <% end %>
-
-  </div>
-
-  <%# PAST OFFERS TABLE %>
-  <h3>Past Offers</h3>
-
-  <div class="requests-table">
-    <%# to be added %>
+    </div>
   </div>
 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,9 @@ Rails.application.routes.draw do
   # this is for "requests received", the show of each request an expert received
   get "requests_received/:id", to: "requests#requests_received_show", as: "request_received"
 
-  patch "cancel/:id", to: "requests#cancel", as: "request_cancelled"
   patch "reject/:id", to: "requests#reject", as: "request_rejected"
+  delete "requests/:id", to: "requests#destroy_rejected_request", as: "destroy_rejected_request"
 
-  delete "requests/:id", to: "requests#destroy_client_request", as: "request_deleted"
+  patch "cancel/:id", to: "requests#cancel", as: "request_cancelled"
+  delete "requests/:id", to: "requests#destroy_cancelled_request", as: "destroy_cancelled_request"
 end


### PR DESCRIPTION
-	Cf explanation on slack
On top of that:
-	Removed the status tags for reject/cancelled/past (not useful, action call instead)
-	When we create a new request, changed the redirect to arrive on the show page instead of the index
-	Made the request show box fixed on scroll
-	Cannot cancel/reject a request once the offer is accepted
-	Removed hover on request that are not clickable (rejected/cancelled)
